### PR TITLE
Improve adapter missing-gem error messages (v0.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [Unreleased]
 
+## [0.2.1] - 2025-01-27
+
+### Changed
+
+- **Adapter missing-gem error messages** (MySQL, PostgreSQL, SQL Server): replace platform-specific system library install instructions with links to official documentation. Messages now include `gem install` and a single link for system libraries.
+
 ## [0.2.0] - 2025-10-12
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dwh (0.2.0)
+    dwh (0.2.1)
       connection_pool (~> 2.4)
       csv (~> 3.3.5)
       faraday

--- a/lib/dwh/adapters/athena.rb
+++ b/lib/dwh/adapters/athena.rb
@@ -202,8 +202,15 @@ module DWH
       def valid_config?
         super
         require 'aws-sdk-athena'
+        require 'aws-sdk-s3'
       rescue LoadError
-        raise ConfigError, "Required 'aws-sdk-athena' and 'aws-sdk-s3' gems missing. Please add them to your Gemfile."
+        raise ConfigError, <<~MSG
+          Athena adapter requires the 'aws-sdk-athena' and 'aws-sdk-s3' gems.
+
+          Install with: gem install aws-sdk-athena aws-sdk-s3
+
+          No system libraries required (pure Ruby).
+        MSG
       end
 
       private

--- a/lib/dwh/adapters/duck_db.rb
+++ b/lib/dwh/adapters/duck_db.rb
@@ -209,7 +209,13 @@ module DWH
         super
         require 'duckdb'
       rescue LoadError
-        raise ConfigError, "Required 'duckdb' gem missing. Please add it to your Gemfile."
+        raise ConfigError, <<~MSG
+          DuckDB adapter requires the 'duckdb' gem.
+
+          Install with: gem install duckdb
+
+          See https://github.com/suketa/ruby-duckdb for installation details.
+        MSG
       end
 
       private

--- a/lib/dwh/adapters/my_sql.rb
+++ b/lib/dwh/adapters/my_sql.rb
@@ -219,7 +219,16 @@ module DWH
         super
         require 'mysql2'
       rescue LoadError
-        raise ConfigError, "Required 'MySql2' gem missing. Please add it to your Gemfile."
+        raise ConfigError, <<~MSG
+          MySQL adapter requires the 'mysql2' gem.
+
+          Install with: gem install mysql2
+
+          System libraries required:
+            macOS:  brew install mysql
+            Ubuntu: sudo apt-get install libmysqlclient-dev
+            RHEL:   sudo dnf install mysql-devel
+        MSG
       end
 
       def result_to_csv(result)

--- a/lib/dwh/adapters/my_sql.rb
+++ b/lib/dwh/adapters/my_sql.rb
@@ -224,11 +224,7 @@ module DWH
 
           Install with: gem install mysql2
 
-          System libraries required:
-            macOS:  brew install mysql
-            Ubuntu: sudo apt-get install libmysqlclient-dev
-            RHEL:   sudo dnf install mysql-devel
-            Windows: vcpkg (https://vcpkg.io) or https://dev.mysql.com/downloads/mysql/
+          System libraries: https://dev.mysql.com/downloads/
         MSG
       end
 

--- a/lib/dwh/adapters/my_sql.rb
+++ b/lib/dwh/adapters/my_sql.rb
@@ -228,6 +228,7 @@ module DWH
             macOS:  brew install mysql
             Ubuntu: sudo apt-get install libmysqlclient-dev
             RHEL:   sudo dnf install mysql-devel
+            Windows: vcpkg (https://vcpkg.io) or https://dev.mysql.com/downloads/mysql/
         MSG
       end
 

--- a/lib/dwh/adapters/postgres.rb
+++ b/lib/dwh/adapters/postgres.rb
@@ -230,6 +230,7 @@ module DWH
             macOS:  brew install postgresql
             Ubuntu: sudo apt-get install libpq-dev
             RHEL:   sudo dnf install postgresql-devel
+            Windows: vcpkg (https://vcpkg.io) or https://www.postgresql.org/download/windows/
         MSG
       end
 

--- a/lib/dwh/adapters/postgres.rb
+++ b/lib/dwh/adapters/postgres.rb
@@ -221,7 +221,16 @@ module DWH
         super
         require 'pg'
       rescue LoadError
-        raise ConfigError, "Required 'pg' gem missing. Please add it to your Gemfile."
+        raise ConfigError, <<~MSG
+          PostgreSQL adapter requires the 'pg' gem.
+
+          Install with: gem install pg
+
+          System libraries required:
+            macOS:  brew install postgresql
+            Ubuntu: sudo apt-get install libpq-dev
+            RHEL:   sudo dnf install postgresql-devel
+        MSG
       end
 
       private

--- a/lib/dwh/adapters/postgres.rb
+++ b/lib/dwh/adapters/postgres.rb
@@ -226,11 +226,7 @@ module DWH
 
           Install with: gem install pg
 
-          System libraries required:
-            macOS:  brew install postgresql
-            Ubuntu: sudo apt-get install libpq-dev
-            RHEL:   sudo dnf install postgresql-devel
-            Windows: vcpkg (https://vcpkg.io) or https://www.postgresql.org/download/windows/
+          System libraries: https://www.postgresql.org/download/
         MSG
       end
 

--- a/lib/dwh/adapters/sql_server.rb
+++ b/lib/dwh/adapters/sql_server.rb
@@ -234,7 +234,16 @@ module DWH
         super
         require 'tiny_tds'
       rescue LoadError
-        raise ConfigError, "Required 'tiny_tds' gem missing. Please add it to your Gemfile."
+        raise ConfigError, <<~MSG
+          SQL Server adapter requires the 'tiny_tds' gem.
+
+          Install with: gem install tiny_tds
+
+          System libraries required (FreeTDS):
+            macOS:  brew install freetds
+            Ubuntu: sudo apt-get install freetds-dev
+            RHEL:   sudo dnf install freetds-devel
+        MSG
       end
 
       private

--- a/lib/dwh/adapters/sql_server.rb
+++ b/lib/dwh/adapters/sql_server.rb
@@ -243,6 +243,7 @@ module DWH
             macOS:  brew install freetds
             Ubuntu: sudo apt-get install freetds-dev
             RHEL:   sudo dnf install freetds-devel
+            Windows: vcpkg (https://vcpkg.io) or http://www.freetds.org/
         MSG
       end
 

--- a/lib/dwh/adapters/sql_server.rb
+++ b/lib/dwh/adapters/sql_server.rb
@@ -239,11 +239,7 @@ module DWH
 
           Install with: gem install tiny_tds
 
-          System libraries required (FreeTDS):
-            macOS:  brew install freetds
-            Ubuntu: sudo apt-get install freetds-dev
-            RHEL:   sudo dnf install freetds-devel
-            Windows: vcpkg (https://vcpkg.io) or http://www.freetds.org/
+          System libraries (FreeTDS): https://www.freetds.org/
         MSG
       end
 

--- a/lib/dwh/adapters/trino.rb
+++ b/lib/dwh/adapters/trino.rb
@@ -194,7 +194,13 @@ module DWH
         super
         require 'trino-client'
       rescue LoadError
-        raise ConfigError, "Required 'trino-client' gem missing. Please add it to your Gemfile."
+        raise ConfigError, <<~MSG
+          Trino adapter requires the 'trino-client' gem.
+
+          Install with: gem install trino-client
+
+          No system libraries required (pure Ruby).
+        MSG
       end
 
       private

--- a/lib/dwh/version.rb
+++ b/lib/dwh/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DWH
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end


### PR DESCRIPTION
## Summary

Improves the `ConfigError` messages shown when a required adapter gem is missing. Instead of a short "add to Gemfile" line, each adapter now prints:
- The gems it needs
- An exact `gem install` command
- A link for system libraries (when needed) or a note that none are required (pure-Ruby adapters)

## Changes

### Error message updates (all affected adapters)

- **Athena**: Require `aws-sdk-s3` in addition to `aws-sdk-athena`; message includes `gem install` and "No system libraries required (pure Ruby)".
- **DuckDB**: `gem install` + link to [ruby-duckdb](https://github.com/suketa/ruby-duckdb).
- **MySQL**: `gem install` + system libraries link (replaces platform-specific brew/apt/dnf instructions).
- **PostgreSQL**: `gem install` + system libraries link (replaces platform-specific instructions).
- **SQL Server**: `gem install` + FreeTDS link (replaces platform-specific instructions).
- **Trino**: `gem install` + "No system libraries required (pure Ruby)".

### Other

- **Athena**: `require 'aws-sdk-s3'` in `valid_config?` so both AWS gems are loaded and missing S3 is reported via the same `ConfigError` instead of a later `NameError`.
- **Version**: 0.2.0 → 0.2.1.
- **CHANGELOG**: Entry for 0.2.1 under "Changed".