### PR TITLE
List all six adapters in 0.2.1 CHANGELOG entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- **Adapter missing-gem error messages** (MySQL, PostgreSQL, SQL Server): replace platform-specific system library install instructions with links to official documentation. Messages now include `gem install` and a single link for system libraries.
+- **Adapter missing-gem error messages** (Athena, DuckDB, MySQL, PostgreSQL, SQL Server, Trino): replace platform-specific system library install instructions with links to official documentation. Messages now include `gem install` and a single link for system libraries.
 
 ## [0.2.0] - 2025-10-12
 


### PR DESCRIPTION
The 0.2.1 CHANGELOG entry for adapter missing-gem error messages only listed MySQL, PostgreSQL, and SQL Server. The change in that release actually touched six adapters.

This PR updates the entry to include all six: Athena, DuckDB, MySQL, PostgreSQL, SQL Server, and Trino.